### PR TITLE
Use ropes instead of repeated string concatenation

### DIFF
--- a/src/lib/lambdoc_read_lambtex_impl/parser.mly
+++ b/src/lib/lambdoc_read_lambtex_impl/parser.mly
@@ -13,6 +13,8 @@ open Globalenv
 let the comm = match comm.Ast.comm_tag with
 	| Some x -> x
 	| None	 -> invalid_arg "the"
+
+let to_string = BatText.to_string
 %}
 
 
@@ -28,9 +30,9 @@ let the comm = match comm.Ast.comm_tag with
 %token <Lambdoc_reader.Ast.command_t> ROW_END
 %token <Lambdoc_reader.Ast.command_t> CELL_MARK
 
-%token <Lambdoc_reader.Ast.command_t * string> PLAIN
+%token <Lambdoc_reader.Ast.command_t * BatText.t> PLAIN
 %token <Lambdoc_reader.Ast.command_t * string> ENTITY
-%token <string> RAW
+%token <BatText.t> RAW
 
 
 /********************************************************************************/
@@ -199,12 +201,12 @@ env_block:
 	| begin_block(blk_qanda) qanda_frag* end_block				{($1, Ast.Qanda $2)}
 	| begin_block(blk_verse) block* end_block				{($1, Ast.Verse $2)}
 	| begin_block(blk_quote) block* end_block				{($1, Ast.Quote $2)}
-	| begin_block(blk_mathtex_blk) RAW end_block				{($1, Ast.Mathtex_blk $2)}
-	| begin_block(blk_mathml_blk) RAW end_block				{($1, Ast.Mathml_blk $2)}
-	| begin_block(blk_source) RAW end_block					{($1, Ast.Source $2)}
+	| begin_block(blk_mathtex_blk) RAW end_block				{($1, Ast.Mathtex_blk (to_string $2))}
+	| begin_block(blk_mathml_blk) RAW end_block				{($1, Ast.Mathml_blk (to_string $2))}
+	| begin_block(blk_source) RAW end_block					{($1, Ast.Source (to_string $2))}
 	| begin_block(blk_tabular) raw_bundle tabular end_block			{($1, Ast.Tabular ($2, $3))}
 	| begin_block(blk_subpage) block* end_block				{($1, Ast.Subpage $2)}
-	| begin_block(blk_verbatim) RAW end_block				{($1, Ast.Verbatim $2)}
+	| begin_block(blk_verbatim) RAW end_block				{($1, Ast.Verbatim (to_string $2))}
 	| begin_block(blk_pullquote) inline_bundle? block* end_block		{($1, Ast.Pullquote ($2, $3))}
 	| begin_block(blk_custom) inline_bundle? block* end_block		{($1, Ast.Custom (None, the $1, $2, $3))}
 	| begin_block(blk_equation) inline_bundle? block end_block		{($1, Ast.Equation ($2, $3))}
@@ -266,11 +268,11 @@ cell:	CELL_MARK raw_bundle? option(inline+)					{($1, $2, $3)}
 /********************************************************************************/
 
 inline:
-	| PLAIN										{let (comm, txt) = $1 in (comm, Ast.Plain txt)}
+	| PLAIN										{let (comm, txt) = $1 in (comm, Ast.Plain (to_string txt))}
 	| ENTITY									{let (comm, ent) = $1 in (comm, Ast.Entity ent)}
 	| LINEBREAK									{($1, Ast.Linebreak)}
-	| BEGIN_MATHTEX_INL push(mathtex_inl) OPEN_DUMMY RAW pop_brk END_MATHTEX_INL	{($1, Ast.Mathtex_inl $4)}
-	| BEGIN_MATHML_INL push(mathml_inl) OPEN_DUMMY RAW pop_brk END_MATHML_INL	{($1, Ast.Mathml_inl $4)}
+	| BEGIN_MATHTEX_INL push(mathtex_inl) OPEN_DUMMY RAW pop_brk END_MATHTEX_INL	{($1, Ast.Mathtex_inl (to_string $4))}
+	| BEGIN_MATHML_INL push(mathml_inl) OPEN_DUMMY RAW pop_brk END_MATHML_INL	{($1, Ast.Mathml_inl (to_string $4))}
 	| GLYPH raw_bundle raw_bundle							{($1, Ast.Glyph ($2, $3))}
 	| BOLD inline_bundle								{($1, Ast.Bold $2)}
 	| EMPH inline_bundle								{($1, Ast.Emph $2)}
@@ -297,7 +299,7 @@ inline:
 /********************************************************************************/
 
 inline_bundle: 		BEGIN push(general) OPEN_DUMMY inline* pop_brk END	{$4}
-raw_bundle: 		BEGIN push(raw) OPEN_DUMMY RAW pop_brk END		{$4}
+raw_bundle: 		BEGIN push(raw) OPEN_DUMMY RAW pop_brk END		{to_string $4}
 
 
 /********************************************************************************/

--- a/src/lib/lambdoc_read_lambtex_impl/tokenizer.ml
+++ b/src/lib/lambdoc_read_lambtex_impl/tokenizer.ml
@@ -256,8 +256,8 @@ object (self)
 	*)
 	method private store token =
 		productions <- match (productions, token) with
-			| ([PLAIN (op1, txt1)], PLAIN (op2, txt2))	-> [PLAIN (op1, txt1 ^ txt2)]
-			| ([RAW txt1], RAW txt2)			-> [RAW (txt1 ^ txt2)]
+			| ([PLAIN (op1, txt1)], PLAIN (op2, txt2))	-> [PLAIN (op1, BatText.append txt1 txt2)]
+			| ([RAW txt1], RAW txt2)			-> [RAW (BatText.append txt1  txt2)]
 			| _						-> productions @ [token]
 
 
@@ -287,10 +287,10 @@ object (self)
 			| `Tok_row_end			-> (Set Tab, [ROW_END op])
 			| `Tok_eof			-> (Hold, [EOF])
 			| `Tok_parbreak			-> (Set Blk, [])
-			| `Tok_space when context = Inl	-> (Hold, [PLAIN (op, " ")])
+			| `Tok_space when context = Inl	-> (Hold, [PLAIN (op, BatText.of_string " ")])
 			| `Tok_space			-> (Hold, [])
-			| `Tok_raw txt			-> (Hold, [RAW txt])
-			| `Tok_plain txt		-> (Set Inl, [PLAIN (op, txt)])
+			| `Tok_raw txt			-> (Hold, [RAW (BatText.of_string txt)])
+			| `Tok_plain txt		-> (Set Inl, [PLAIN (op, BatText.of_string txt)])
 			| `Tok_entity ent		-> (Set Inl, [ENTITY (op, ent)]) in
 		let tokens = match (context, action) with
 			| (Blk, Set Inl) -> (NEW_PAR op) :: tokens


### PR DESCRIPTION
`perf record --call-graph dwarf lambcmd.native -i lzdoc.tex -o lzdoc.html` showed that a lot of time is spent in `camlPervasives__$5e_1104`, and that it also triggers GC minor cycles very often. This would be that Pervasives.(^) function used in tokenizer.ml

This patch reduces lambcmd.native time on a 200kB document with lots of RAW tokens: 10s -> 1.5s
Repeatedly concatenating lots of RAW tokens is an O(N^2) operation and generates
a lot of extra work for the garbage collector too.
Use BatText instead which doesn't concatenate immediately but uses ropes.

(Could also use a string list and concatenate at the very end, but BatText is cleaner)
